### PR TITLE
Upgrade Ant to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,16 @@
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.ant</groupId>
+                <artifactId>ant</artifactId>
+                <version>1.10.13</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>javax.xml.bind</groupId>


### PR DESCRIPTION
to get rid of 4 vulnerabilities. Ant is a transitive dependence from jaxb2-basics-jaxb-xjc.